### PR TITLE
Unify Attribute Representation

### DIFF
--- a/nixui/graphics/diff_widget.py
+++ b/nixui/graphics/diff_widget.py
@@ -4,9 +4,12 @@ import difflib
 
 from nixui.graphics import generic_widgets
 from nixui.options import object_to_expression
+from nixui.options.attribute import Attribute
 
 
 class DiffedOptionListSelector(generic_widgets.ScrollListStackSelector):
+    ItemCls = generic_widgets.OptionListItem
+
     def __init__(self, updates, *args, **kwargs):
         self.updates_map = {
             u.option: (
@@ -26,7 +29,7 @@ class DiffedOptionListSelector(generic_widgets.ScrollListStackSelector):
             self.item_list.addItem(it)
 
     def change_item(self):
-        option = self.item_list.currentItem().text()
+        option = self.item_list.currentItem().option
         old_value, new_value = self.updates_map[option]
 
         diff = difflib.unified_diff(

--- a/nixui/graphics/generic_widgets.py
+++ b/nixui/graphics/generic_widgets.py
@@ -1,4 +1,4 @@
-from PyQt5 import QtWidgets, QtCore
+from PyQt5 import QtWidgets, QtCore, QtGui
 
 from nixui.graphics import richtext, icon
 
@@ -170,3 +170,17 @@ class ScrollListStackSelector(QtWidgets.QWidget):
 
     def set_layout(self):
         self.setLayout(self.hbox)
+
+
+class OptionListItem(QtWidgets.QListWidgetItem):
+    def __init__(self, option, icon_path=None, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self.option = option
+
+        self.set_text()
+        if icon_path:
+            self.setIcon(QtGui.QIcon(icon_path))
+
+    def set_text(self):
+        self.setText(richtext.get_option_html(self.option))

--- a/nixui/graphics/richtext.py
+++ b/nixui/graphics/richtext.py
@@ -34,16 +34,16 @@ class HTMLDelegate(QtWidgets.QStyledItemDelegate):
         return doc
 
 
-def get_option_html(option_name, child_count=None, type_label=None, description=None):
+def get_option_html(option, child_count=None, type_label=None, description=None):
     # TODO: 60% and 100% don't work with QT
     no_margin_style = 'margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px'
     sub_style = f'font-style:italic; color:Gray; font-size:60%; {no_margin_style}'
 
-    fancy_name = option_name.split('.')[-1]
-    capitalized_fancy_name = re.sub(r"(\w)([A-Z])", r"\1 \2", fancy_name).title()
-    child_count = api.get_option_count(option_name)
+    capitalized_fancy_name = re.sub(r"(\w)([A-Z])", r"\1 \2", option.loc[-1]).title()
     s = f'<p style="font-size:100%; {no_margin_style}">{capitalized_fancy_name}</p>'
-    s += f'<p style="{sub_style}">{option_name}{" (" + str(child_count) + ")" if child_count else ""}</p>'
+    if child_count:
+        num_children = api.get_option_count(option)
+        s += f'<p style="{sub_style}">{option}{" (" + str(num_children) + ")" if num_children else ""}</p>'
     if type_label:
         s += f'<p style="{sub_style}">Type: {type_label}</p>'
     if description:

--- a/nixui/options/attribute.py
+++ b/nixui/options/attribute.py
@@ -32,7 +32,7 @@ class Attribute:
         ])
 
     def __bool__(self):
-        return self.loc
+        return bool(self.loc)
 
     def __repr__(self):
         return f'{self.__class__}("{str(self)}")'

--- a/nixui/options/attribute.py
+++ b/nixui/options/attribute.py
@@ -1,0 +1,41 @@
+import csv
+from dataclasses import dataclass, field
+from typing import List
+
+
+@dataclass(frozen=True)
+class Attribute:
+    loc: List[str] = field(default_factory=list)
+
+    @classmethod
+    def from_string(cls, attribute_string):
+        loc = next(csv.reader([attribute_string], delimiter='.', quotechar='"'))
+        return cls(loc)
+
+    @classmethod
+    def from_insertion(cls, attribute_set, attribute):
+        return cls(attribute_set.loc + [attribute])
+
+    def get_set(self):
+        return Attribute(self.loc[:-1])
+
+    def get_end(self):
+        return Attribute(self.loc[-1:])
+
+    def __iter__(self):
+        return iter(self.loc)
+
+    def __str__(self):
+        return '.'.join([
+            f'"{attribute}"' if '.' in attribute else attribute
+            for attribute in self.loc
+        ])
+
+    def __bool__(self):
+        return self.loc
+
+    def __repr__(self):
+        return f'{self.__class__}("{str(self)}")'
+
+    def __hash__(self):
+        return hash(tuple(self.loc))

--- a/nixui/options/object_to_expression.py
+++ b/nixui/options/object_to_expression.py
@@ -22,7 +22,9 @@ def format_expression(expression_str):
 
 
 def get_expression(obj):
-    if isinstance(obj, bool):
+    if obj == ('NO DEFAULT SET',):  # TODO: clean up this hack, api.py and here should have a unified NO DEFAULT SET
+        return '<undefined>'
+    elif isinstance(obj, bool):
         return str(obj).lower()
     elif isinstance(obj, list):
         space_separated = ' '.join([get_expression(elem) for elem in obj])

--- a/nixui/options/syntax_tree.py
+++ b/nixui/options/syntax_tree.py
@@ -1,5 +1,4 @@
 import collections
-from dataclasses import dataclass
 import subprocess
 import json
 import uuid

--- a/nixui/state_model.py
+++ b/nixui/state_model.py
@@ -59,7 +59,6 @@ class StateModel:
 
             self.current_values[option] = new_value
 
-
     def persist_updates(self):
         option_new_value_map = {
             u.option: u.new_value

--- a/nixui/tests/test_state_model.py
+++ b/nixui/tests/test_state_model.py
@@ -1,16 +1,17 @@
 import os
 import pytest
 from nixui import state_model
+from nixui.options.attribute import Attribute
 
 
 SAMPLES_PATH = 'tests/sample'
 
 
 @pytest.mark.parametrize('option_loc,new_value', [
-    ('sound.enable', False),  # boolean
-    ('services.logind.lidSwitch', 'dosomething'),  # string
-    ('services.redshift.temperature.day', 1000),  # integer
-    ('services.networking.firewall.allowedTCPPorts', [1, 2, 3, 4, 5]),  # list of ints
+    (Attribute.from_string('sound.enable'), False),  # boolean
+    (Attribute.from_string('services.logind.lidSwitch'), 'dosomething'),  # string
+    (Attribute.from_string('services.redshift.temperature.day'), 1000),  # integer
+    (Attribute.from_string('services.networking.firewall.allowedTCPPorts'), [1, 2, 3, 4, 5]),  # list of ints
     #('users.extraUsers.sample.isNormalUser', False),  # modify submodule
 ])
 @pytest.mark.datafiles(SAMPLES_PATH)


### PR DESCRIPTION
In nix-gui we repeat ourselves in handling conversions from different representations of the attribute path and potentially create bugs with inconsistent representation of `Attribute`s. They could be either a `list` of attribute keys (`["environment", "etc", "resolv.conf", "text"]`) or string (`environment.etc."resolv.conf".text`). It was unclear what type attributes were and they'd have to be converted back and forth multiple times.

This change introduces the `Attribute` class. An immutable class which defines both a `str` representation, a `bool` representation, and allows iteration over the list of attribute keys.

Now we needn't apply any conversions between the representation of an `Attribute` except in cases where a string is expected such as title setting within Qt.