### PR TITLE
Color Nav List Based on Changes in memory or persisted in nix-config

### DIFF
--- a/nixui/graphics/color_indicator.py
+++ b/nixui/graphics/color_indicator.py
@@ -10,23 +10,11 @@ def get_edit_state_color_indicator(tree, option_path):
     configured_definition exists: yellow
     system_default_definition: white
     """
-    undefined = OptionDefinition.undefined()
-
-    configured_definition_exists = False
-    in_memory_definition_exists = False
-
-    for child_option_path, data in tree.children(option_path, mode="full").items():
-        if data is None:
-            continue
-        if data.in_memory_definition != undefined:
-            in_memory_definition_exists = True
-            break
-        if data.configured_definition != undefined:
-            configured_definition_exists = True
-
-    if in_memory_definition_exists:
+    # in memory definition change
+    if option_path in tree.get_change_set_with_ancestors():
         return QtGui.QColor(214, 253, 221)  # light green
-    elif configured_definition_exists:
+    # in configuration definition change
+    elif option_path in tree.get_change_set_with_ancestors(get_configured_changes=True):
         return QtGui.QColor(245, 241, 197)  # yellow
     else:
         return QtGui.QColor(255, 255, 255)  # white

--- a/nixui/graphics/color_indicator.py
+++ b/nixui/graphics/color_indicator.py
@@ -1,0 +1,32 @@
+from PyQt5 import QtGui
+
+from nixui.options.option_definition import OptionDefinition
+
+
+def get_edit_state_color_indicator(tree, option_path):
+    """
+    Select color based on whether the option path or any child paths have been changed
+    in_memory_definition: green
+    configured_definition exists: yellow
+    system_default_definition: white
+    """
+    undefined = OptionDefinition.undefined()
+
+    configured_definition_exists = False
+    in_memory_definition_exists = False
+
+    for child_option_path, data in tree.children(option_path, mode="full").items():
+        if data is None:
+            continue
+        if data.in_memory_definition != undefined:
+            in_memory_definition_exists = True
+            break
+        if data.configured_definition != undefined:
+            configured_definition_exists = True
+
+    if in_memory_definition_exists:
+        return QtGui.QColor(214, 253, 221)  # light green
+    elif configured_definition_exists:
+        return QtGui.QColor(245, 241, 197)  # yellow
+    else:
+        return QtGui.QColor(255, 255, 255)  # white

--- a/nixui/graphics/field_widgets.py
+++ b/nixui/graphics/field_widgets.py
@@ -5,7 +5,7 @@ import re
 from PyQt5 import QtWidgets, QtGui, QtCore
 
 from nixui.options import api, option_tree, option_definition
-from nixui.graphics import richtext, generic_widgets
+from nixui.graphics import color_indicator, richtext, generic_widgets
 
 
 # tuples of (match fn, widget)
@@ -208,20 +208,24 @@ class GenericOptionDisplay(QtWidgets.QWidget):
             any(w.hasFocus() for w in self.field_type_selector.btn_group.buttons())
         )
 
-    def paint_background_color(self, *bg_color_tuple):
+    def paint_background_color(self, bg_color):
         qp = QtGui.QPainter(self)
         r = QtCore.QRect(0, 0, self.width(), self.height())
-        qp.fillRect(r, QtGui.QColor.fromRgb(*bg_color_tuple))
+        qp.fillRect(r, bg_color)
         qp.end()
 
     def paintEvent(self, ev):
         super().paintEvent(ev)
         if self.contains_focus():
-            self.paint_background_color(233, 245, 248, 255)
-        elif self.starting_definition != self.definition:
-            self.paint_background_color(194, 249, 197, 255)
+            self.paint_background_color(
+                QtGui.QColor(233, 245, 248)
+            )
         else:
-            return
+            bg_color = color_indicator.get_edit_state_color_indicator(
+                api.get_option_tree(),
+                self.option
+            )
+            self.paint_background_color(bg_color)
         self.update()
 
 

--- a/nixui/graphics/nav_interface.py
+++ b/nixui/graphics/nav_interface.py
@@ -60,7 +60,7 @@ class OptionNavigationInterface(QtWidgets.QWidget):
         )
         # if 10 or fewer options, navlist with lowest level attribute selected and list of editable fields to the right
         # otherwise, show list of attributes within the clicked attribute and blank to the right
-        num_children = len(api.get_option_tree().children(option_path, recursive=True))
+        num_children = len(api.get_option_tree().children(option_path, mode="leaves"))
         if num_children <= 10:
             self.nav_list.replace_widget(
                 navlist.GenericNavListDisplay(
@@ -118,7 +118,7 @@ class FieldsGroupBox(QtWidgets.QWidget):
         vbox = QtWidgets.QVBoxLayout()
 
         for child_option_path in api.get_option_tree().children(option):
-            if len(api.get_option_tree().children(child_option_path, recursive=True)) > 1:
+            if len(api.get_option_tree().children(child_option_path)) > 1:
                 vbox.addWidget(FieldsGroupBox(
                     statemodel,
                     child_option_path,

--- a/nixui/graphics/navlist.py
+++ b/nixui/graphics/navlist.py
@@ -3,7 +3,7 @@ import csv
 
 from PyQt5 import QtWidgets, QtCore, QtGui
 
-from nixui.graphics import icon, richtext
+from nixui.graphics import icon, richtext, color_indicator
 from nixui.options.attribute import Attribute
 from nixui.options import api, option_definition
 
@@ -64,7 +64,9 @@ class ChildCountOptionListItem(QtWidgets.QListWidgetItem):
 
         self.option = option
 
-        child_count = len(api.get_option_tree().children(self.option)) if use_child_count else None
+        tree = api.get_option_tree()
+
+        child_count = len(tree.children(self.option)) if use_child_count else None
         self.setText(
             richtext.get_option_html(
                 self.option,
@@ -73,6 +75,13 @@ class ChildCountOptionListItem(QtWidgets.QListWidgetItem):
                 extra_text=extra_text
             )
         )
+
+        bg_color = color_indicator.get_edit_state_color_indicator(
+            tree,
+            self.option
+        )
+        bg_brush = QtGui.QBrush(bg_color)
+        self.setForeground(bg_brush)
 
         if icon_path:
             self.setIcon(QtGui.QIcon(icon_path))

--- a/nixui/graphics/richtext.py
+++ b/nixui/graphics/richtext.py
@@ -3,6 +3,7 @@ import re
 from PyQt5 import QtWidgets, QtGui, QtCore
 
 from nixui.options import api
+from nixui.graphics import color_indicator
 
 
 class HTMLDelegate(QtWidgets.QStyledItemDelegate):
@@ -53,4 +54,8 @@ def get_option_html(option, use_fancy_name=True, child_count=None, type_label=No
         s += f'<p style="{sub_style}">Description: {description}</p>'
     if extra_text:
         s += f'<p style="{sub_style}">{extra_text}</p>'
-    return s
+
+    color = color_indicator.get_edit_state_color_indicator(api.get_option_tree(), option)
+    return f"""
+    <div style="background-color: {color.name()}">{s}</div>
+    """

--- a/nixui/options/attribute.py
+++ b/nixui/options/attribute.py
@@ -26,6 +26,12 @@ class Attribute:
     def __bool__(self):
         return bool(self.loc)
 
+    def __getitem__(self, subscript):
+        if isinstance(subscript, slice):
+            return Attribute(self.loc[subscript])
+        else:
+            return self.loc[subscript]
+
     def __iter__(self):
         return iter(self.loc)
 

--- a/nixui/options/option_tree.py
+++ b/nixui/options/option_tree.py
@@ -171,15 +171,25 @@ class OptionTree:
     def is_readonly(self, attribute):
         return self._get_data(attribute).readOnly
 
-    def children(self, attribute, recursive=False):
-        if recursive:
-            children = self.tree.leaves(attribute)
-        else:
+    def children(self, attribute, mode="direct"):
+        """
+        attribute: the key to explore children of
+        mode:
+        - "direct": get direct descendents
+        - "full": get all descendents
+        - "leaves": get only descendents which have no children
+        """
+        if mode == "direct":
             children = self.tree.children(attribute)
-        return [
-            node.tag for node in children
+        elif mode == "full":
+            children = Tree(self.tree.subtree(attribute)).all_nodes()
+        elif mode == "leaves":
+            children = self.tree.leaves(attribute)
+        return {
+            node.tag: node.data
+            for node in children
             if '"<name>"' not in node.tag
-        ]
+        }
 
     def get_next_branching_option(self, attribute):
         while len(self.children(attribute)) == 1:


### PR DESCRIPTION
fixes https://github.com/nix-gui/nix-gui/issues/27

- [x] color nav list widget items
- [X] optimize `OptionTree` ~with caching~ by replacing `treelib` with a custom implementation using pandas.
  - ~(partially done, still a bit slow though)~ working quickly with better caching

Profiling info:
- program consumes ~650MB while running
- with `--no-diskcache` bootup takes 17 seconds
- tests run in 22 seconds

(detailed profiling report in comment)