### PR TITLE
Cache option getting

### DIFF
--- a/nixui/options/nix_eval.py
+++ b/nixui/options/nix_eval.py
@@ -8,6 +8,11 @@ from nixui.utils import cache
 from nixui.options.attribute import Attribute
 
 
+cache_by_unique_installed_nixos_nixpkgs_version = cache.cache(
+    lambda: nix_instantiate_eval("with import <nixpkgs/nixos> {}; pkgs.lib.version")
+)
+
+
 def nix_instantiate_eval(expr, strict=False):
     logger.debug(expr)
     cmd = [
@@ -26,11 +31,7 @@ def nix_instantiate_eval(expr, strict=False):
     return json.loads(res)
 
 
-def get_nixpkgs_version():
-    return nix_instantiate_eval("with import <nixpkgs> {}; lib.version")
-
-
-@functools.lru_cache()  # TODO: more efficient retain_hash_fn:  @cache(return_copy=True, retain_hash_fn=get_nixpkgs_version)
+@cache_by_unique_installed_nixos_nixpkgs_version
 def get_all_nixos_options():
     """
     Get a JSON representation of `<nixpkgs/nixos>` options.


### PR DESCRIPTION
Use diskcached `get_all_nixos_options` to reduce startup time. `get_all_nixos_options` now takes an ignorable amount of time

Startup time before change:
```
   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        1    0.025    0.025   23.965   23.965 main.py:45(run_program)
        1    0.000    0.000   15.231   15.231 state_model.py:25(__init__)
        1    0.001    0.001   15.231   15.231 api.py:12(get_option_tree)
      3/2    0.003    0.001   12.012    6.006 cache.py:56(wrapper)
        3    0.001    0.000   11.766    3.922 nix_eval.py:16(nix_instantiate_eval)
        4    0.000    0.000   11.687    2.922 subprocess.py:464(run)
        3    0.000    0.000   11.672    3.891 subprocess.py:377(check_output)
       16   11.667    0.729   11.667    0.729 {method 'read' of '_io.BufferedReader' objects}
        5    0.000    0.000   11.662    2.332 subprocess.py:1090(communicate)
        1    0.000    0.000    8.591    8.591 nix_eval.py:34(get_all_nixos_options)
```

After (`get_all_nixos_options` not in abbreviated list):
```
   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        1    0.042    0.042   14.291   14.291 main.py:45(run_program)
        1    0.000    0.000    9.891    9.891 state_model.py:25(__init__)
        1    0.001    0.001    9.891    9.891 api.py:12(get_option_tree)
      3/2    0.005    0.002    5.474    2.737 cache.py:56(wrapper)
        2    0.000    0.000    5.106    2.553 nix_eval.py:16(nix_instantiate_eval)
       14    5.101    0.364    5.101    0.364 {method 'read' of '_io.BufferedReader' objects}
        2    0.000    0.000    5.100    2.550 subprocess.py:377(check_output)
        2    0.000    0.000    5.100    2.550 subprocess.py:464(run)
        3    0.000    0.000    5.087    1.696 subprocess.py:1090(communicate)
        1    0.029    0.029    4.359    4.359 option_tree.py:39(__init__)
```
