### PR TITLE
Recursively Parse Imported Modules

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -86,7 +86,7 @@
                 export NIX_PATH=nixpkgs=${pkgs.path}:nixos-config=${sample}/configuration.nix
                 cd nixui
               '' + (if !enable-profiling then ''
-                python3 -m pytest
+                python3 -m pytest -vv
               '' else ''
                 python3 -m cProfile -o profile -m pytest
                 python3 -c "import pstats; p = pstats.Stats('profile'); p.strip_dirs(); p.sort_stats('cumtime'); p.print_stats(50)"

--- a/nixui/graphics/field_widgets.py
+++ b/nixui/graphics/field_widgets.py
@@ -9,38 +9,38 @@ from nixui.graphics import color_indicator, richtext, generic_widgets
 
 
 def get_field_widget_classes_from_type(option_type):
-    if isinstance(option_type, types.ListOf):
+    if isinstance(option_type, types.ListOfType):
         return [ListOfRedirect]
-    elif isinstance(option_type, types.AttrsOf):
+    elif isinstance(option_type, types.AttrsOfType):
         return [AttrsOfRedirect]
-    elif isinstance(option_type, types.Attrs):
+    elif isinstance(option_type, types.AttrsType):
         return [AttrsRedirect]
-    elif isinstance(option_type, types.Submodule):
+    elif isinstance(option_type, types.SubmoduleType):
         return [SubmoduleRedirect]
-    elif isinstance(option_type, types.Either):
+    elif isinstance(option_type, types.EitherType):
         widgets = set()
         for subtype in option_type.subtypes:
             widgets |= set(get_field_widget_classes_from_type(subtype))
         return list(widgets)
-    elif isinstance(option_type, types.Unspecified):
+    elif isinstance(option_type, types.UnspecifiedType):
         return [UndefinedField]
-    elif isinstance(option_type, types.Null):
+    elif isinstance(option_type, types.NullType):
         return [NullField]
-    elif isinstance(option_type, types.Bool):
+    elif isinstance(option_type, types.BoolType):
         return [BooleanField]
-    elif isinstance(option_type, types.Str):
+    elif isinstance(option_type, types.StrType):
         return [TextField]
-    elif isinstance(option_type, types.Int):
+    elif isinstance(option_type, types.IntType):
         return [IntegerField]
-    elif isinstance(option_type, types.OneOf):
+    elif isinstance(option_type, types.OneOfType):
         return [OneOfField]
-    elif isinstance(option_type, types.Path):
+    elif isinstance(option_type, types.PathType):
         return [NotImplementedField]
-    elif isinstance(option_type, types.Package):
+    elif isinstance(option_type, types.PackageType):
         return [NotImplementedField]
-    elif isinstance(option_type, types.Function):
+    elif isinstance(option_type, types.FunctionType):
         return [NotImplementedField]
-    elif isinstance(option_type, types.Anything):
+    elif isinstance(option_type, types.AnythingType):
         return [NotImplementedField]
     else:
         raise NotImplementedError(option_type)
@@ -207,22 +207,22 @@ class Redirect(QtWidgets.QLabel):
 
 
 class SubmoduleRedirect(Redirect):
-    option_type = types.Submodule
+    option_type = types.SubmoduleType
     name = "Submodule"
 
 
 class ListOfRedirect(Redirect):
-    option_type = types.ListOf
+    option_type = types.ListOfType
     name = "List of"
 
 
 class AttrsRedirect(Redirect):
-    option_type = types.Attrs
+    option_type = types.AttrsType
     name = "Attrs"
 
 
 class AttrsOfRedirect(Redirect):
-    option_type = types.AttrsOf
+    option_type = types.AttrsOfType
     name = "Attrs of"
 
 

--- a/nixui/graphics/nav_interface.py
+++ b/nixui/graphics/nav_interface.py
@@ -67,7 +67,7 @@ class OptionNavigationInterface(QtWidgets.QWidget):
         # if 10 or fewer options, navlist with lowest level attribute selected and list of editable fields to the right
         # otherwise, show list of attributes within the clicked attribute and blank to the right
         # TODO: option type checking should probably take place in the same place where all type -> field resolving occurs
-        if option_type in (types.Attrs, types.AttrsOf, types.ListOf) or num_children > 10:
+        if option_type in (types.AttrsType, types.AttrsOfType, types.ListOfType) or num_children > 10:
             self.nav_list.replace_widget(
                 navlist.GenericNavListDisplay(
                     self.statemodel,

--- a/nixui/graphics/navlist.py
+++ b/nixui/graphics/navlist.py
@@ -14,9 +14,9 @@ class GenericNavListDisplay:
             option_type = types.from_nix_type_str(
                 api.get_option_tree().get_type(option_path)
             )
-        if option_type == types.AttrsOf:
+        if option_type == types.AttrsOfType:
             return DynamicAttrsOf(statemodel, option_path, set_option_path_fn, selected)
-        elif option_type == types.ListOf:
+        elif option_type == types.ListOfType:
             return DynamicListOf(statemodel, option_path, set_option_path_fn, selected)
         else:
             return StaticAttrsOf(option_path, set_option_path_fn, selected)

--- a/nixui/nix/lib.nix
+++ b/nixui/nix/lib.nix
@@ -18,7 +18,13 @@ in lib.makeExtensible (self: {
 
   /* Extract the declarations of a module
   */
-  evalModuleStub = module_path: import module_path { inherit lib; name = ""; config = {}; pkgs = {}; };
+  evalModuleStub = module_path: import module_path {
+    inherit lib;
+    name = "";
+    config = {};
+    pkgs = {};
+    modulesPath = builtins.dirOf module_path;
+  };
 
   /* Get all NixOS options as a list of options with the following schema:
     {

--- a/nixui/options/nix_eval.py
+++ b/nixui/options/nix_eval.py
@@ -102,6 +102,11 @@ def get_modules_import_position(module_path):
     # TODO: should be part of lib.nix
     expression = f"""
     builtins.unsafeGetAttrPos "imports"
-    (import {module_path} {{config = {{}}; pkgs = import <nixpkgs> {{}}; lib = {{}};}})
+    (import {module_path} {{
+      config = {{}};
+      pkgs = import <nixpkgs> {{}};
+      lib = {{}};
+      modulesPath = builtins.dirOf {module_path};
+    }})
     """
     return nix_instantiate_eval(expression, strict=True)

--- a/nixui/options/nix_eval.py
+++ b/nixui/options/nix_eval.py
@@ -1,4 +1,3 @@
-import os
 import json
 import subprocess
 import functools
@@ -59,10 +58,12 @@ def nix_instantiate_eval(expr, strict=False, show_trace=False, retry_show_trace_
     else:
         return json.loads(out)
 
+
 @contextmanager
 def find_library(name):
     with importlib.resources.path('nixui.nix', f'lib.nix') as f:
         yield f'(import {f}).{name}'
+
 
 @cache_by_unique_installed_nixos_nixpkgs_version
 def get_all_nixos_options():

--- a/nixui/options/option_definition.py
+++ b/nixui/options/option_definition.py
@@ -105,7 +105,7 @@ class OptionDefinition:
         elif obj is None:
             return types.NullType()
         else:
-            raise Exception
+            raise NotImplementedError
 
     @property
     def expression_string(self):

--- a/nixui/options/option_definition.py
+++ b/nixui/options/option_definition.py
@@ -87,13 +87,13 @@ def get_formatted_expression(obj):
 
 @functools.lru_cache()
 def format_expression(expression_str):
-    if True:#with LogPipe('INFO') as log_pipe:
+    if True:  # with LogPipe('INFO') as log_pipe:
         p = subprocess.run(
             ['nixpkgs-fmt'],
             stdout=subprocess.PIPE,
             input=expression_str,
             encoding='ascii',
-            stderr=subprocess.PIPE,#log_pipe,
+            stderr=subprocess.PIPE,  # log_pipe,
         )
         return p.stdout
 

--- a/nixui/options/option_definition.py
+++ b/nixui/options/option_definition.py
@@ -190,9 +190,9 @@ def get_expression(obj):
         raise TypeError(str((type(obj), obj)))
 
 
-#############################
-# Expression string to object
-#############################
+################################################
+# Syntax tree (from expression string) to object
+################################################
 def expression_node_to_python_object(value_node, context):
     if value_node.name == 'NODE_LIST':
         # recursively generate list object

--- a/nixui/options/option_definition.py
+++ b/nixui/options/option_definition.py
@@ -1,12 +1,10 @@
 import dataclasses
-import json
 import functools
 import os
 import subprocess
 
 from nixui.options import nix_eval, syntax_tree, types
 from nixui.utils.singleton import Singleton
-from nixui.utils.logger import logger
 from nixui.utils import hash_by_json
 
 
@@ -159,15 +157,14 @@ def get_formatted_expression(obj):
 
 @functools.lru_cache()
 def format_expression(expression_str):
-    if True:  # with LogPipe('INFO') as log_pipe:
-        p = subprocess.run(
-            ['nixpkgs-fmt'],
-            stdout=subprocess.PIPE,
-            input=expression_str,
-            encoding='ascii',
-            stderr=subprocess.PIPE,  # log_pipe,
-        )
-        return p.stdout
+    p = subprocess.run(
+        ['nixpkgs-fmt'],
+        stdout=subprocess.PIPE,
+        input=expression_str,
+        encoding='ascii',
+        stderr=subprocess.PIPE,  # log_pipe,
+    )
+    return p.stdout
 
 
 def get_expression(obj):

--- a/nixui/options/option_definition.py
+++ b/nixui/options/option_definition.py
@@ -45,8 +45,9 @@ class OptionDefinition:
     - todo: ???
     """
     def __init__(self, context=None, **kwargs):
-        self.context = context or {}
+        assert kwargs != {}
         self.passed = kwargs
+        self.context = context or {}
 
     @classmethod
     def from_object(cls, obj, context=None):

--- a/nixui/options/option_definition.py
+++ b/nixui/options/option_definition.py
@@ -1,31 +1,65 @@
+import dataclasses
 import json
 import functools
+import os
 import subprocess
 
-from nixui.options import nix_eval
+from nixui.options import nix_eval, syntax_tree, types
 from nixui.utils.singleton import Singleton
 from nixui.utils.logger import logger
+from nixui.utils import hash_by_json
 
 
 Unresolvable = Singleton('Unresolvable')
 Undefined = Singleton('Undefined')
 
 
+@dataclasses.dataclass(frozen=True, unsafe_hash=True)
+class Path:
+    path: str = None
+    cwd: str = None
+
+    def eval_full_path(self):
+        return os.path.join(
+            os.path.normpath(self.cwd),
+            os.path.normpath(self.path)
+        )
+
+
 class OptionDefinition:
     """
     A unified representation of an expression, with @properties providing both the python and string form
+
+    Can be constructed using either a python object, an expression string, or an expression ast node
+    Properties are dynamically loaded to reduce unnecessary computations
+
+    Conversions from passed value to @property
+    - ast node -> expression string
+    - ast node -> object
+    - expression string -> ast node -> object
+    - object -> expression string
+    - object -> object type
+
+    Note that there is no @property for ast_node
+
+    Some conversions require context to be passed. The context dict can have the following values:
+    - cwd: Used to get the absolute path from a relative path
+    - todo: ???
     """
-    def __init__(self, **kwargs):
-        assert ('expression_string' in kwargs) != ('obj' in kwargs)  # one or the other but not both
+    def __init__(self, context=None, **kwargs):
+        self.context = context or {}
         self.passed = kwargs
 
     @classmethod
-    def from_object(cls, obj):
-        return cls(obj=obj)
+    def from_object(cls, obj, context=None):
+        return cls(obj=obj, context=context)
 
     @classmethod
-    def from_expression_string(cls, expression_string):
-        return cls(expression_string=expression_string)
+    def from_expression_string(cls, expression_string, context=None):
+        return cls(expression_string=expression_string, context=context)
+
+    def from_ast_node(cls, ast_node, context=None):
+        return cls(ast_node=ast_node, context=context)
 
     @classmethod
     def undefined(cls):
@@ -36,14 +70,43 @@ class OptionDefinition:
     def obj(self):
         if 'obj' in self.passed:
             return self.passed['obj']
-        elif not self.passed['expression_string']:
+        elif not self.expression_string:
             return Undefined
         else:
-            try:
-                return nix_eval.nix_instantiate_eval(self.passed['expression_string'])
-            except Exception as e:
-                logger.error(e)
-                return Unresolvable
+            return expression_node_to_python_object(
+                self._get_ast_node(),
+                self.context
+            )
+
+    @property
+    @functools.lru_cache()
+    def obj_type(self):
+        return self.get_object_type(self.obj)
+
+    @classmethod
+    def get_object_type(cls, obj):
+        if isinstance(obj, list):
+            subtypes = set([cls.get_object_type(elem) for elem in obj])
+            if len(subtypes) == 0:
+                return types.ListOfType()
+            if len(subtypes) == 1:
+                return types.ListOfType(subtypes.pop())
+            else:
+                return types.ListOfType(types.EitherType(subtypes))
+        elif isinstance(obj, bool):
+            return types.BoolType()
+        elif isinstance(obj, int):
+            return types.IntType()
+        elif isinstance(obj, float):
+            return types.FloatType()
+        elif isinstance(obj, str):
+            return types.StrType()
+        elif isinstance(obj, Path):
+            return types.PathType()
+        elif obj is None:
+            return types.NullType()
+        else:
+            raise Exception
 
     @property
     def expression_string(self):
@@ -51,6 +114,15 @@ class OptionDefinition:
             return self.passed['expression_string']
         else:
             return get_formatted_expression(self.passed['obj'])
+
+    @functools.lru_cache()
+    def _get_ast_node(self):
+        if 'ast_node' in self.passed:
+            return self.passed['ast_node']
+        tree = syntax_tree.SyntaxTree.from_string(self.passed['expression_string'])
+        root_node = tree.elem_ids[tree.root_id]
+        assert len(root_node.elems) == 1
+        return root_node.elems[0]
 
     @property
     def is_undefined(self):
@@ -62,7 +134,7 @@ class OptionDefinition:
     def __hash__(self):
         return hash((
             self.passed.get('expression_string'),
-            json.dumps(self.passed.get('obj'), sort_keys=True)
+            hash_by_json.hash_object(self.passed.get('obj'))
         ))
 
     def __eq__(self, other):
@@ -100,7 +172,7 @@ def format_expression(expression_str):
 
 def get_expression(obj):
     if obj == Undefined:
-        return Undefined
+        return ''
     elif isinstance(obj, bool):
         return str(obj).lower()
     elif isinstance(obj, list):
@@ -118,3 +190,66 @@ def get_expression(obj):
         return "null"
     else:
         raise TypeError(str((type(obj), obj)))
+
+
+#############################
+# Expression string to object
+#############################
+def expression_node_to_python_object(value_node, context):
+    if value_node.name == 'NODE_LIST':
+        # recursively generate list object
+        return [
+            expression_node_to_python_object(child_node, context)
+            for child_node in value_node.elems
+            if isinstance(child_node, syntax_tree.Node)
+        ]
+
+    elif value_node.name == 'NODE_STRING':
+        assert value_node.elems[0].name == 'TOKEN_STRING_START'
+        assert value_node.elems[-1].name == 'TOKEN_STRING_END'
+        python_obj = ''
+        for child_node in value_node.elems[1:-1]:
+            if child_node.name == 'TOKEN_STRING_CONTENT':
+                python_obj += child_node.quoted
+            elif child_node.name == 'NODE_STRING_INTERPOL':
+                return Unresolvable  # TODO: handle string interpolation
+            else:
+                return Unresolvable  # TODO
+        return python_obj
+
+    elif value_node.name == 'NODE_IDENT':
+        if len(value_node.elems) == 1 and value_node.elems[0].name == 'TOKEN_IDENT':
+            if value_node.elems[0].quoted == 'true':
+                return True
+            elif value_node.elems[0].quoted == 'false':
+                return False
+            else:
+                return Unresolvable  # TODO
+
+    elif value_node.name == 'NODE_LITERAL':
+        if len(value_node.elems) == 1:
+            if value_node.elems[0].name == 'NODE_PATH':
+                return Unresolvable  # TODO
+            if value_node.elems[0].name == 'TOKEN_PATH':
+                return Path(
+                    value_node.elems[0].quoted,
+                    context['module_dir'],
+                )
+            elif value_node.elems[0].name == 'TOKEN_INTEGER':
+                return int(value_node.elems[0].quoted)
+            elif value_node.elems[0].name == 'TOKEN_URI':
+                return str(value_node.elems[0].quoted)
+            elif value_node.elems[0].name == 'TOKEN_FLOAT':
+                return float(value_node.elems[0].quoted)
+
+    elif value_node.name == 'NODE_WITH':
+        # TODO: handle with statement using rnix-lsp
+        return Unresolvable
+
+    else:
+        try:
+            return nix_eval.nix_instantiate_eval(value_node.to_string())
+        except nix_eval.NixEvalError:
+            return Unresolvable
+
+    raise ValueError(value_node.to_string())

--- a/nixui/options/parser.py
+++ b/nixui/options/parser.py
@@ -57,7 +57,7 @@ def apply_indentation(string, num_spaces):
 
 @cache.cache(return_copy=True, retain_hash_fn=cache.first_arg_path_hash_fn)
 def get_all_option_values(module_path):
-    logger.info(f'Retrieving option values for module "{module_path}"'
+    logger.info(f'Retrieving option values for module "{module_path}"')
     # get option_expr_map for module_path
     option_expr_map = {}
     tree = syntax_tree.SyntaxTree(module_path)

--- a/nixui/options/parser.py
+++ b/nixui/options/parser.py
@@ -1,4 +1,3 @@
-import os
 import uuid
 
 from nixui.utils.logger import logger

--- a/nixui/options/parser.py
+++ b/nixui/options/parser.py
@@ -63,7 +63,7 @@ def get_all_option_values(module_path):
     tree = syntax_tree.SyntaxTree(module_path)
     for attr_loc, (key_node, value_node) in get_key_value_nodes(module_path, tree).items():
         option_expr_map[attr_loc] = OptionDefinition.from_expression_string(
-            tree.to_string(value_node)
+            value_node.to_string()
         )
 
     # get imports node from syntax tree and recurse if possible
@@ -87,7 +87,7 @@ def get_all_option_values(module_path):
             # TODO: this isn't the correct way to merge attributes between modules, it needs to be implemented
             option_expr_map.update(get_all_option_values(full_import_path))
         except nix_eval.NixEvalError as e:
-            logger.error(e)
+            logger.error(e)  # TODO: ensure all legal import elements are resolved and don't `continue`
             continue
 
     return option_expr_map

--- a/nixui/options/parser.py
+++ b/nixui/options/parser.py
@@ -1,9 +1,10 @@
 import os
 import uuid
 
+from nixui.utils.logger import logger
 from nixui.utils import cache
 from nixui.options import syntax_tree, nix_eval
-from nixui.options.option_definition import OptionDefinition
+from nixui.options.option_definition import OptionDefinition, Unresolvable
 
 
 def inject_expressions(module_path, option_expr_map):
@@ -56,30 +57,47 @@ def apply_indentation(string, num_spaces):
 
 
 @cache.cache(return_copy=True, retain_hash_fn=cache.first_arg_path_hash_fn)
-def get_all_option_values(root_module_path):
+def get_all_option_values(module_path):
+    logger.info(f'Retrieving option values for module "{module_path}"'
+    # get option_expr_map for module_path
     option_expr_map = {}
-    for module_path in [root_module_path]:
-        tree = syntax_tree.SyntaxTree(module_path)
-        for attr_loc, (key_node, value_node) in get_key_value_nodes(module_path, tree).items():
-            option_expr_map[attr_loc] = OptionDefinition.from_expression_string(
-                tree.to_string(value_node)
-            )
-
-        # recurse for all imports
-        imports_node = get_imports_node(module_path, tree)
-        _, imports_value_node = [e for e in imports_node.elems if isinstance(e, syntax_tree.Node)]
-        imports_definition = OptionDefinition.from_expression_string(
-            imports_value_node.to_string()
+    tree = syntax_tree.SyntaxTree(module_path)
+    for attr_loc, (key_node, value_node) in get_key_value_nodes(module_path, tree).items():
+        option_expr_map[attr_loc] = OptionDefinition.from_expression_string(
+            tree.to_string(value_node)
         )
-        for import_path in imports_definition.obj:
-            full_import_path = os.path.join(os.dirname(root_module_path), import_path)
-            option_expr_map.update(**get_all_option_values(full_import_path))
+
+    # get imports node from syntax tree and recurse if possible
+    imports_node = get_imports_node(module_path, tree)
+    if imports_node is None:
+        return option_expr_map
+
+    # extract definition from imports_node
+    _, imports_value_node = [e for e in imports_node.elems if isinstance(e, syntax_tree.Node)]
+    imports_definition = OptionDefinition.from_expression_string(
+        imports_value_node.to_string(),
+        {'module_dir': os.path.dirname(module_path)}
+    )
+    # for each valid parsable import, recurse
+    for i, import_path in enumerate(imports_definition.obj):
+        if import_path == Unresolvable:
+            logger.error(f'failed to load element {i} of \n{imports_definition.expression_string}')
+            continue
+        full_import_path = import_path.eval_full_path()
+        try:
+            # TODO: this isn't the correct way to merge attributes between modules, it needs to be implemented
+            option_expr_map.update(get_all_option_values(full_import_path))
+        except nix_eval.NixEvalError as e:
+            logger.error(e)
+            continue
 
     return option_expr_map
 
 
 def get_imports_node(module_path, tree):
     import_pos = nix_eval.get_modules_import_position(module_path)
+    if import_pos is None:
+        return None
     return tree.get_node_at_line_column(
         import_pos['line'],
         import_pos['column'],

--- a/nixui/options/parser.py
+++ b/nixui/options/parser.py
@@ -1,3 +1,4 @@
+import os
 import uuid
 
 from nixui.utils.logger import logger

--- a/nixui/tests/test_option_definition.py
+++ b/nixui/tests/test_option_definition.py
@@ -1,4 +1,4 @@
-from nixui.options.option_definition import OptionDefinition
+from nixui.options.option_definition import OptionDefinition, Undefined
 
 
 def test_expr_string_from_obj():
@@ -9,3 +9,18 @@ def test_expr_string_from_obj():
 def test_obj_from_expr_string():
     d = OptionDefinition.from_expression_string('if true then "bla" else "foo"')
     assert d.obj == "bla"
+
+
+def test_equality_undefined():
+    assert OptionDefinition.from_object(Undefined) == OptionDefinition.from_object(Undefined)
+
+
+def test_import_path():
+    d = OptionDefinition.from_expression_string(
+        """[
+        ./hardware-configuration.nix
+        ]""",
+        context={'module_dir': '/foo'},
+    )
+    assert len(d.obj) == 1
+    assert d.obj[0].eval_full_path() == '/foo/hardware-configuration.nix'

--- a/nixui/tests/test_parser.py
+++ b/nixui/tests/test_parser.py
@@ -11,3 +11,100 @@ def test_get_all_option_values():
     assert parser.get_all_option_values(
         os.path.abspath(os.path.join(SAMPLES_PATH, 'configuration.nix'))
     )
+
+
+@pytest.mark.datafiles(SAMPLES_PATH)
+def test_get_all_option_values_correct_attributes():
+    module_path = os.path.abspath(os.path.join(SAMPLES_PATH, 'configuration.nix'))
+    found_attrs = set([str(x) for x in parser.get_all_option_values(module_path)])
+
+    # exclude `imports`
+    configuration_nix_attrs = {
+        'environment.etc',
+        'environment.systemPackages',
+        'fileSystems',
+        'fonts.fontDir.enable',
+        'fonts.fonts',
+        'hardware.bluetooth.enable',
+        'hardware.bluetooth.settings',
+        'hardware.opengl.driSupport32Bit',
+        'hardware.pulseaudio.enable',
+        'hardware.pulseaudio.extraModules',
+        'hardware.pulseaudio.package',
+        'hardware.pulseaudio.support32Bit',
+        'networking.firewall.allowPing',
+        'networking.firewall.allowedTCPPorts',
+        'networking.firewall.enable',
+        'networking.hostId',
+        'networking.hostName',
+        'networking.networkmanager.enable',
+        'programs.vim.defaultEditor',
+        'programs.zsh.enable',
+        'security.sudo.extraConfig',
+        'services.blueman.enable',
+        'services.bookstack.nginx',
+        'services.dbus.enable',
+        'services.dbus.packages',
+        'services.logind.lidSwitch',
+        'services.printing.drivers',
+        'services.printing.enable',
+        'services.redshift.enable',
+        'services.redshift.temperature.day',
+        'services.redshift.temperature.night',
+        'services.unbound.enable',
+        'services.unbound.settings',
+        'services.xserver.displayManager.lightdm.enable',
+        'services.xserver.displayManager.sessionCommands',
+        'services.xserver.enable',
+        'services.xserver.synaptics.enable',
+        'services.xserver.windowManager.i3.enable',
+        'services.xserver.xkbOptions',
+        'sound.enable',
+        'system.stateVersion',
+        'time.timeZone',
+        'users.extraGroups',
+        'users.extraUsers',
+        'virtualisation.libvirtd.enable'
+    }
+    hardware_configuration_nix_attrs = {
+        'boot.extraModulePackages',
+        'boot.initrd.availableKernelModules',
+        'boot.initrd.kernelModules',
+        'boot.kernelModules',
+        'swapDevices'
+    }
+
+    # TODO: add these to the expected set when `lib.nix` recurses into submodules
+    configuration_nix_submodule_attrs = {
+        'users.extraUsers.isNormalUser',
+        'users.extraUsers.home',
+        'users.extraUsers.description',
+        'users.extraUsers.extraGroups',
+        'users.extraUsers.uid',
+        'users.extraUsers.shell',
+        'users.extraGroups.vboxusers.members',
+        'services.bookstack.nginx.listen',
+        'services.unbound.settings.server.cache-min-ttl',
+        'services.unbound.settings.server.do-tcp',
+        'services.unbound.settings.server.ssl-upstream',
+        'services.unbound.settings.forwrad-zone',
+        'environment.etc."resolv.conf".text',
+        'hardware.bluetooth.settings.General.Enable',
+        'fileSystems."/".options',
+    }
+    hardware_configuration_nix_submodule_attrs = {
+        'fileSystems."/".device',
+        'fileSystems."/".fsType',
+        'fileSystems."/boot".device',
+        'fileSystems."/boot".fsType',
+        'fileSystems."/home".fsType',
+        'fileSystems."/home".device',
+        'fileSystems."/home/geir/media".device',
+        'fileSystems."/home/geir/media".fsType',
+    }
+
+    # TODO: add cases when `lib.nix` recurses into lists, e.g.
+    # 'swapDevices.[0].device', 'users.extraUsers.sample'.extraGroups.[3]'
+
+    expected_attrs = configuration_nix_attrs | hardware_configuration_nix_attrs
+    assert found_attrs == expected_attrs

--- a/nixui/tests/test_types.py
+++ b/nixui/tests/test_types.py
@@ -4,17 +4,18 @@ from nixui.options import types
 def test_integration_load_specific_options(nix_gui_main_window):
     nix_type_str = '16 bit unsigned integer; between 0 and 65535 (both inclusive) or one of "auto" or submodule or list of 16 bit unsigned integer; between 0 and 65535 (both inclusive) or one of "auto" or submodules'
     option_type = types.from_nix_type_str(nix_type_str)
-    assert option_type == types.Either(
+    expected = types.EitherType(
         subtypes=[
-            types.Int(minimum=0, maximum=65535),
-            types.OneOf(choices=['auto']),
-            types.Submodule(),
-            types.ListOf(
-                subtype=types.Either(
+            types.IntType(minimum=0, maximum=65535),
+            types.OneOfType(choices=['auto']),
+            types.SubmoduleType(),
+            types.ListOfType(
+                subtype=types.EitherType(
                     subtypes=[
-                        types.Int(minimum=0, maximum=65535),
-                        types.OneOf(choices=['auto']),
-                        types.Submodule()
+                        types.IntType(minimum=0, maximum=65535),
+                        types.OneOfType(choices=['auto']),
+                        types.SubmoduleType()
                     ]),
                 )
         ])
+    assert option_type == expected

--- a/nixui/utils/hash_by_json.py
+++ b/nixui/utils/hash_by_json.py
@@ -1,0 +1,19 @@
+import dataclasses
+import json
+
+
+# https://stackoverflow.com/questions/51286748/make-the-python-json-encoder-support-pythons-new-dataclasses/51286749#51286749
+class EnhancedJSONEncoder(json.JSONEncoder):
+    def default(self, o):
+        if dataclasses.is_dataclass(o):
+            return dataclasses.asdict(o)
+        return super().default(o)
+
+
+def hash_object(obj):
+    json_string = json.dumps(
+        obj,
+        sort_keys=True,
+        cls=EnhancedJSONEncoder,
+    )
+    return hash(json_string)

--- a/nixui/utils/singleton.py
+++ b/nixui/utils/singleton.py
@@ -13,6 +13,3 @@ class Singleton:
 
     def __repr__(self):
         return f'Singleton("{self.name}")'
-
-    def toJSON(self):
-        return f'SINGLETON {self.name}'

--- a/nixui/utils/singleton.py
+++ b/nixui/utils/singleton.py
@@ -1,6 +1,9 @@
+import dataclasses
+
+
+@dataclasses.dataclass(frozen=True, unsafe_hash=True)
 class Singleton:
-    def __init__(self, name):
-        self.name = name
+    name: str
 
     def __eq__(self, other):
         return (
@@ -10,3 +13,6 @@ class Singleton:
 
     def __repr__(self):
         return f'Singleton("{self.name}")'
+
+    def toJSON(self):
+        return f'SINGLETON {self.name}'


### PR DESCRIPTION
(necessary for https://github.com/nix-gui/nix-gui/issues/21)

- less ambiguous variable names (`types.ListOf` -> `types.ListOfType`, `types.Foo` -> `types.FooType`)
- pass `modulesPath` to `evalModuleStub`
- hash based on json representation of object, make `dataclasses` "json-hashable" to cache `OptionDefinition`
  - (enables `lru_cache` based on `OptionDefinition` passed python object)
- convert `OptionDefinition` expression string to python object
- implement `get_imports_node` 

All of this to implement recursively parsing imports. For a given module we
- extract its option-definition map
- get the imports node from the modules syntax tree
- create`OptionDefinition` from imports node expression string
- get python object (list) representation of `imports` `OptionDefinition`
- iterate over list of imports (`Path` type)
- recurse for the import path