### PR TITLE
Fix run commands

### DIFF
--- a/docs/usage.org
+++ b/docs/usage.org
@@ -5,10 +5,10 @@ Prerequisites:
 
 
 Run
-- =nix run github:nix-gui/nix-gui nix-gui=
+- =nix run github:nix-gui/nix-gui=
 
 Print help string
-- =nix run github:nix-gui/nix-gui nix-gui -- --help=
+- =nix run github:nix-gui/nix-gui --help=
 
 
 * Interface


### PR DESCRIPTION
The commands required to run doesn't seem to require me to use executable name (errors because nix-gui isn't a valid command argument)

Tested on NixOS 21.11 (Porcupine) x86_64.