### PR TITLE
 implement AnythingType.subtypes, fix dynamic list/attrs qualification

### DIFF
--- a/nixui/graphics/nav_interface.py
+++ b/nixui/graphics/nav_interface.py
@@ -95,10 +95,13 @@ class OptionNavigationInterface(QtWidgets.QWidget):
         option_def = api.get_option_tree().get_definition(option_path)
         dynamic_navlist_types = (types.AttrsOfType, types.ListOfType)
         option_type = option_type or api.get_option_tree().get_type(option_path)
-        if isinstance(option_type, types.AnythingType) and isinstance(option_def._type, dynamic_navlist_types):
-            option_type = option_def._type
-        elif isinstance(option_type, types.EitherType) and any([isinstance(t, dynamic_navlist_types) for t in option_def._type.subtypes]):
-            option_type = option_def._type
+
+        # if the option can legally be a dynamic navlist and its current value is a dynamic navlist, use that type
+        if isinstance(option_type, (types.AnythingType, types.EitherType)):
+            if any([isinstance(t, dynamic_navlist_types) for t in option_type.subtypes]):
+                if any([isinstance(t, dynamic_navlist_types) for t in option_def._type.subtypes]):
+                    option_type = option_def._type
+        # else if it has a strict type (not Anything or Either), let that type determine whether it qualifies
 
         show_path_in_navlist = (
             not display_as_single_field and (

--- a/nixui/graphics/option_display.py
+++ b/nixui/graphics/option_display.py
@@ -13,7 +13,7 @@ def get_field_widget_classes_from_type(option_type):
         return [field_widgets.AttrsRedirect]
     elif isinstance(option_type, types.SubmoduleType):
         return [field_widgets.SubmoduleRedirect]
-    elif isinstance(option_type, types.EitherType):
+    elif isinstance(option_type, (types.EitherType, types.AnythingType)):
         widgets = set()
         for subtype in option_type.subtypes:
             widgets |= set(get_field_widget_classes_from_type(subtype))
@@ -37,8 +37,6 @@ def get_field_widget_classes_from_type(option_type):
     elif isinstance(option_type, types.PackageType):
         return [field_widgets.NotImplementedField]
     elif isinstance(option_type, types.FunctionType):
-        return [field_widgets.NotImplementedField]
-    elif isinstance(option_type, types.AnythingType):
         return [field_widgets.NotImplementedField]
     else:
         raise NotImplementedError(option_type)

--- a/nixui/options/types.py
+++ b/nixui/options/types.py
@@ -263,7 +263,7 @@ class AnythingType(NixType):
             NullType(),
             SubmoduleType(),
             # OneOfType(), excluded, redundant with StrType
-            # UnspecifiedType(), excluded for now, should later be integrated
+            # UnspecifiedType(), excluded, it must be specified
         )
 
 

--- a/nixui/options/types.py
+++ b/nixui/options/types.py
@@ -248,6 +248,24 @@ class AnythingType(NixType):
     def child_type(self):
         return AnythingType()
 
+    @property
+    def subtypes(self):
+        return (
+            BoolType(),
+            IntType(),
+            FloatType(),
+            StrType(),
+            PathType(),
+            PackageType(),
+            FunctionType(),
+            ListOfType(),
+            AttrsOfType(),
+            NullType(),
+            SubmoduleType(),
+            OneOfType(),
+            UnspecifiedType(),
+        )
+
 
 @dataclasses.dataclass(frozen=True, unsafe_hash=True)
 class BoolType(NixType):
@@ -331,7 +349,6 @@ class EitherType(NixType):
             return EitherType(possibilities)
         else:
             raise TypeError("Attempted to get child types, but no Either.subtypes allow children.", self)
-
 
 
 

--- a/nixui/options/types.py
+++ b/nixui/options/types.py
@@ -262,8 +262,8 @@ class AnythingType(NixType):
             AttrsOfType(),
             NullType(),
             SubmoduleType(),
-            OneOfType(),
-            UnspecifiedType(),
+            # OneOfType(), excluded, redundant with StrType
+            # UnspecifiedType(), excluded for now, should later be integrated
         )
 
 


### PR DESCRIPTION
fixes `boot.loader.timeout` load resulting in

```
Traceback (most recent call last):
  File "/nix/store/bqnb4hmrr7xgvn3carkh580ggnij2j5s-python3.9-nix-gui-0.1.2/lib/python3.9/site-packages/nixui/graphics/navlist.py", line 411, in set_option_path_callback
    self.set_option_path_fn(
  File "/nix/store/bqnb4hmrr7xgvn3carkh580ggnij2j5s-python3.9-nix-gui-0.1.2/lib/python3.9/site-packages/nixui/graphics/nav_interface.py", line 100, in set_option_path
    elif isinstance(option_type, types.EitherType) and any([isinstance(t, dynamic_navlist_types) for t in option_def._type.subtypes]):
AttributeError: 'AnythingType' object has no attribute 'subtypes'
```

Also fixes https://github.com/nix-gui/nix-gui/issues/182