### PR TITLE
Speed up startup

### DIFF
--- a/nixui/options/api.py
+++ b/nixui/options/api.py
@@ -1,7 +1,6 @@
-import copy
 import os
 
-from nixui.options import parser, nix_eval, option_tree, types
+from nixui.options import parser, nix_eval, option_tree
 from nixui.utils import cache, store, remap_dict
 
 
@@ -13,17 +12,13 @@ def get_option_tree(configuration_path=None):
     if configuration_path is None:
         configuration_path = os.environ['CONFIGURATION_PATH']
 
-    system_option_data_dict = remap_dict.key_remapper(
-        nix_eval.get_all_nixos_options(),
-        {'system_default': 'system_default_definition'}
-    )
-    for key, value in system_option_data_dict.items():
-        system_option_data_dict[key]['type_string'] = system_option_data_dict[key]['type']
-        if 'type' in value:
-            system_option_data_dict[key]['type'] = types.from_nix_type_str(system_option_data_dict[key]['type'])
-        else:
-            system_option_data_dict[key]['type'] = types.AttrsType()
-
+    system_option_data_dict = {
+        option_path: remap_dict.key_remapper(
+            option_data_dict,
+            {'system_default': 'system_default_definition', 'type': 'type_string'}
+        )
+        for option_path, option_data_dict in nix_eval.get_all_nixos_options().items()
+    }
     return option_tree.OptionTree(
         system_option_data_dict,
         parser.get_all_option_values(configuration_path)

--- a/nixui/options/option_tree.py
+++ b/nixui/options/option_tree.py
@@ -16,10 +16,17 @@ class OptionData:
     description: str = Undefined
     readOnly: bool = Undefined
     _type_string: str = Undefined
-    _type: types.NixType = types.AnythingType()
+    _type: types.NixType = Undefined
     system_default_definition: OptionDefinition = OptionDefinition.undefined()
     configured_definition: OptionDefinition = OptionDefinition.undefined()
     in_memory_definition: OptionDefinition = OptionDefinition.undefined()
+
+    def __post_init__(self):
+        if self._type == Undefined:
+            if self._type_string == Undefined:
+                self._type = types.AttrsType()
+            else:
+                self._type = types.from_nix_type_str(self._type_string)
 
     # based on https://stackoverflow.com/a/61426351
     def update(self, new):


### PR DESCRIPTION
Before: 55 seconds

After: 17 seconds

fixes https://github.com/nix-gui/nix-gui/issues/194

Changes to improve time:
- removed deepcopy from `api.get_option_tree` (55 seconds -> 53 seconds)
- load option types from option type strings at runtime rather than when starting the program (53 seconds -> 17 seconds)

Further work expected to reduce startup time to ~7 seconds https://github.com/nix-gui/nix-gui/issues/197 (outside of the scope of this PR)