### PR TITLE
Add example text extraction for tooltip

### DIFF
--- a/nixui/graphics/option_display.py
+++ b/nixui/graphics/option_display.py
@@ -92,11 +92,13 @@ class GenericOptionDisplay(QtWidgets.QWidget):
         text = generic_widgets.ClickableLabel(str(option))
         text.clicked.connect(lambda: set_option_path_fn(option))
         description_text = api.get_option_tree().get_description(option)
+        example = api.get_option_tree().get_example(option)
         tooltip = generic_widgets.ToolTip(
             richtext.get_option_html(
                 option,
                 type_label=api.get_option_tree().get_type_string(option),
                 description=description_text if description_text != option_definition.Undefined else None,
+                example=example if example != option_definition.Undefined else None,
             )
         )
         option_details_layout = QtWidgets.QHBoxLayout()

--- a/nixui/graphics/richtext.py
+++ b/nixui/graphics/richtext.py
@@ -44,7 +44,7 @@ class OptionListItemDelegate(QtWidgets.QStyledItemDelegate):
         return doc
 
 
-def get_option_html(option, use_fancy_name=True, child_count=None, type_label=None, description=None, extra_text=None):
+def get_option_html(option, use_fancy_name=True, child_count=None, type_label=None, description=None, example=None, extra_text=None):
     # TODO: 60% and 100% don't work with QT
     no_margin_style = 'margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px'
     sub_style = f'font-style:italic; color:Gray; font-size:60%; {no_margin_style}'
@@ -61,6 +61,8 @@ def get_option_html(option, use_fancy_name=True, child_count=None, type_label=No
         s += f'<p style="{sub_style}">Type: {type_label}</p>'
     if description:
         s += f'<p style="{sub_style}">Description: {docbook_to_html(description)}</p>'
+    if example:
+        s += f'<p style="{sub_style}">Example: {example_to_html(example)}</p>'
     if extra_text:
         s += f'<p style="{sub_style}">{extra_text}</p>'
     return s
@@ -71,3 +73,12 @@ def docbook_to_html(docbook_str):
         return pypandoc.convert_text(docbook_str, 'html', format='docbook')
     except RuntimeError:
         return None  # handle case - pandoc errors due to invalid XML
+
+def example_to_html(example):
+    """
+    Examples can use `literalExample` or `literalExpression` fields for raw text so we can extract that here.
+    """
+    if isinstance(example, dict):
+        if example.get("_type") in ["literalExample", "literalExpression"]:
+            return example["text"]
+    return example

--- a/nixui/nix/lib.nix
+++ b/nixui/nix/lib.nix
@@ -69,6 +69,7 @@ in lib.makeExtensible (self: {
     {
       "option.name": {
         "description": String              # description declared on the option
+        "example": Optional, Any           # example declared on the option
         "loc": [ String ]                  # the path of the option e.g.: [ "services" "foo" "enable" ]
         "readOnly": Bool                   # is the option user-customizable?
         "type": String                     # either "boolean", "set", "list", "int", "float", or "string"

--- a/nixui/options/nix_eval.py
+++ b/nixui/options/nix_eval.py
@@ -87,6 +87,7 @@ def get_all_nixos_options():
     {
       "option.name": {
         "description": String              # description declared on the option
+        "example": Optional, Any           # example declared on the option
         "loc": [ String ]                  # the path of the option e.g.: [ "services" "foo" "enable" ]
         "readOnly": Bool                   # is the option user-customizable?
         "type": String                     # either "boolean", "set", "list", "int", "float", or "string"

--- a/nixui/options/option_tree.py
+++ b/nixui/options/option_tree.py
@@ -14,6 +14,7 @@ from nixui.options.option_definition import OptionDefinition, Undefined
 class OptionData:
     is_declared_option: bool = False  # the node is part of a declaraed option or part of Attrs/List defining one
     description: str = Undefined
+    example = Undefined
     readOnly: bool = Undefined
     _type_string: str = Undefined
     _type: types.NixType = Undefined
@@ -243,6 +244,9 @@ class OptionTree:
 
     def get_description(self, attribute):
         return self._get_data(attribute).description
+
+    def get_example(self, attribute):
+        return self._get_data(attribute).example
 
     def is_readonly(self, attribute):
         return self._get_data(attribute).readOnly


### PR DESCRIPTION
This defaults to using the example as is, unless it is of the
`literalExample` or `literalExpression` type.

Fixes #122 