### PR TITLE
Statemodel update refresh

### DIFF
--- a/nixui/graphics/diff_widget.py
+++ b/nixui/graphics/diff_widget.py
@@ -29,6 +29,8 @@ class DiffedOptionListSelector(generic_widgets.ScrollListStackSelector):
     def change_selected_item(self):
         option = self.item_list.currentItem().option
         old_value, new_value = self.updates_map[option]
+        old_value = old_value if old_value is not None else ''
+        new_value = new_value if new_value is not None else ''
 
         diff = difflib.unified_diff(
             old_value.splitlines(1),

--- a/nixui/graphics/field_widgets.py
+++ b/nixui/graphics/field_widgets.py
@@ -247,6 +247,8 @@ class OneOfComboBoxField(QtWidgets.QComboBox):
 class OneOfField:
     def __new__(cls, option):
         field_type = api.get_option_tree().get_type(option)
+        if isinstance(field_type, types.EitherType):
+            field_type = field_type.get_child_type(types.OneOfType)
 
         if len(field_type.choices) < 5:
             return OneOfRadioFrameField(option, field_type.choices)

--- a/nixui/graphics/generic_widgets.py
+++ b/nixui/graphics/generic_widgets.py
@@ -3,6 +3,36 @@ from PyQt5 import QtWidgets, QtCore, QtGui
 from nixui.graphics import richtext, icon
 
 
+class DoubleClickableQListWidget(QtWidgets.QListWidget):
+    """
+    ensure single and double click are mutually exclusive
+    based on https://stackoverflow.com/a/22171158
+    """
+    itemWasSingleClicked = QtCore.pyqtSignal()
+    itemWasDoubleClicked = QtCore.pyqtSignal()
+
+    DOUBLE_CLICK_TIMEOUT = 200  # ms
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.itemClicked.connect(self._handle_item_clicked)
+        self._item_double_clicked = False
+        self.itemDoubleClicked.connect(self._handle_item_double_clicked)
+
+    def _handle_item_clicked(self, event):
+        if not self._item_double_clicked:
+            QtCore.QTimer.singleShot(300, self._item_clicked_timeout)
+
+    def _item_clicked_timeout(self):
+        if not self._item_double_clicked:
+            self.itemWasSingleClicked.emit()
+        self._item_double_clicked = False
+
+    def _handle_item_double_clicked(self, *args, **kwargs):
+        self._item_double_clicked = True
+        self.itemWasDoubleClicked.emit()
+
+
 class ReplacableWidget(QtWidgets.QStackedWidget):
     def __init__(self, starting_widget=None):
         super().__init__()

--- a/nixui/graphics/navlist.py
+++ b/nixui/graphics/navlist.py
@@ -265,11 +265,6 @@ class DynamicAttrsOf(QtWidgets.QWidget):
     def remove_clicked(self):
         self.list_widget.takeItem(self.list_widget.currentItem())
 
-    def insert_items(self):
-        for option in api.get_option_tree().children(self.option_path):
-            it = self.ItemCls(option)
-            self.list_widget.addItem(it)
-
 
 class DynamicListOf(QtWidgets.QWidget):
     def __init__(self, statemodel, option_path, set_option_path_fn, selected=None, *args, **kwargs):
@@ -358,10 +353,6 @@ class DynamicListOf(QtWidgets.QWidget):
         self.list_widget.load_data()
         self.list_widget.set_current_option(current_option[-1])
 
-    def insert_items(self):
-        for option in api.get_option_tree().children(self.option_path):
-            it = self.ItemCls(option)
-            self.list_widget.addItem(it)
 
 
 class SearchResultListDisplay(QtWidgets.QListWidget):

--- a/nixui/graphics/navlist.py
+++ b/nixui/graphics/navlist.py
@@ -334,6 +334,7 @@ class DynamicListOf(QtWidgets.QWidget):
             self.list_widget.item(current_row).option,
             self.list_widget.item(current_row - 1).option
         )
+        self.list_widget.setCurrentRow(current_row - 1)
         self.refresh()
 
     def down_clicked(self):
@@ -345,14 +346,12 @@ class DynamicListOf(QtWidgets.QWidget):
             self.list_widget.item(current_row).option,
             self.list_widget.item(current_row + 1).option
         )
+        self.list_widget.setCurrentRow(current_row + 1)
         self.refresh()
 
     def refresh(self):
         current_option = self.list_widget.currentItem().option
-        self.list_widget.clear()
-        self.list_widget.load_data()
-        self.list_widget.set_current_option(current_option[-1])
-
+        self.list_widget.set_option_path_fn(current_option)
 
 
 class SearchResultListDisplay(QtWidgets.QListWidget):

--- a/nixui/options/attribute.py
+++ b/nixui/options/attribute.py
@@ -35,7 +35,7 @@ class Attribute:
                 return False
         return True
 
-    def is_list_index(self, key_idx):
+    def is_list_index(self, key_idx=-1):
         """
         Determines whether the key at index idx is a list index.
         For example, in foo.bar."[5]".baz, the 2nd key, "[5]" is a list index

--- a/nixui/options/option_tree.py
+++ b/nixui/options/option_tree.py
@@ -148,10 +148,10 @@ class OptionTree:
             return tree
 
     def _get_data(self, attribute):
-        result = self.tree.get_node(attribute).data
-        if result == None:
-            raise ValueError()
-        return result
+        result = self.tree.get_node(attribute)
+        if result is None or result.data is None:
+            return OptionData()
+        return result.data
 
     def get_changes(self, get_configured_changes=False):
         """
@@ -216,7 +216,7 @@ class OptionTree:
             self.in_memory_diff[old_attribute] = None
 
         # update tree
-        self.tree.update_node(old_attribute, identifier=new_attribute, tag=new_attribute)
+        self._upsert_node_data(new_attribute, {'in_memory_definition': self.get_in_memory_definition(old_attribute)})
         for old_child_attribute in self.children(new_attribute):
             new_child_attribute = Attribute.from_insertion(new_attribute, old_child_attribute.get_end())
             self.rename_attribute(old_child_attribute, new_child_attribute)

--- a/nixui/options/option_tree.py
+++ b/nixui/options/option_tree.py
@@ -304,8 +304,8 @@ class OptionTree:
             raise ValueError()
 
         # all or no children are list indices, if they all are, sort them
-        if children[0].is_list_index():
-            assert all([c.data.is_list_index() for c in children])
+        if children and children[0].tag.is_list_index():
+            assert all([c.tag.is_list_index() for c in children])
             children = sorted(children, key=lambda c: c.tag)
         return {
             node.tag: node.data

--- a/nixui/options/option_tree.py
+++ b/nixui/options/option_tree.py
@@ -50,7 +50,7 @@ class OptionTree:
     system_option_data: mapping from Attribute to dict containing {'description', 'readOnly', 'type', 'default'}
     config_options: mapping from Attribute to configured definition
 
-    in_memory_change_cache is a dictionary storing all changes made to the tree. This makes calculating the hash of
+    in_memory_diff is a dictionary storing all changes made to the tree. This makes calculating the hash of
     the OptionTree trivial. Note that a value of `None` indicates deletion of the definition.
     """
     def __init__(self, system_option_data, config_options):
@@ -203,18 +203,21 @@ class OptionTree:
 
     def rename_attribute(self, old_attribute, new_attribute):
         # update in_memory_diff
-        if old_attribute in self.in_memory_diff:
-            self.in_memory_diff[new_attribute] = self.in_memory_diff[old_attribute]
-            # if its not defined in configuration, deletion results in no diff recorded
-            if self.get_configured_definition(old_attribute) == OptionDefinition.undefined():
-                del self.in_memory_diff[old_attribute]
-            # if defined in configuration, record None to indicate deletion
-            else:
-                self.in_memory_diff[old_attribute] = None
+
+        # give new attribute the old definition if it is defined
+        old_definition = self.get_definition(old_attribute)
+        if old_definition != OptionDefinition.undefined():
+            self.in_memory_diff[new_attribute] = old_definition
+
+        # mark old attribute for deletion, or if its not on disk, simply remove from diff
+        if self.get_configured_definition(old_attribute) == OptionDefinition.undefined():
+            self.in_memory_diff.pop(old_attribute, None)
+        else:
+            self.in_memory_diff[old_attribute] = None
+
         # update tree
         self.tree.update_node(old_attribute, identifier=new_attribute, tag=new_attribute)
-        for node in self.tree.children(new_attribute):
-            old_child_attribute = node.identifier
+        for old_child_attribute in self.children(new_attribute):
             new_child_attribute = Attribute.from_insertion(new_attribute, old_child_attribute.get_end())
             self.rename_attribute(old_child_attribute, new_child_attribute)
 
@@ -310,7 +313,7 @@ class OptionTree:
         return {
             node.tag: node.data
             for node in children
-            if '"<name>"' not in node.tag
+            if '<name>' not in node.tag
         }
 
     @functools.lru_cache(100000)  # this breaks when nixos has 100,000 attributes

--- a/nixui/options/option_tree.py
+++ b/nixui/options/option_tree.py
@@ -302,6 +302,11 @@ class OptionTree:
                 raise ValueError()
         except treelib.exceptions.NodeIDAbsentError:
             raise ValueError()
+
+        # all or no children are list indices, if they all are, sort them
+        if children[0].is_list_index():
+            assert all([c.data.is_list_index() for c in children])
+            children = sorted(children, key=lambda c: c.tag)
         return {
             node.tag: node.data
             for node in children

--- a/nixui/options/parser.py
+++ b/nixui/options/parser.py
@@ -61,7 +61,7 @@ def apply_remove_definition(tree, option, current_datetime):
     for attr, node in valid_matching_attr_nodes.items():
         if attr[:len(option)] == option:
             # if list index, remove the element, otherwise remove the key in the attribute set too
-            if attr.is_list_index(-1):
+            if attr.is_list_index():
                 assert tree.get_parent(node).name == 'NODE_LIST'
             else:
                 node = tree.get_parent(node)

--- a/nixui/options/state_update.py
+++ b/nixui/options/state_update.py
@@ -47,7 +47,7 @@ class ChangeDefinitionUpdate(Update):
         option_tree.set_definition(self.attribute, self.old_definition)
 
     def merge_with_previous_update(self, previous_update):
-        if isinstance(previous_update, (CreateUpdate, ChangeDefinitionUpdate)):
+        if isinstance(previous_update, (CreateUpdate, ChangeDefinitionUpdate, SwapNamesUpdate)):
             return None
         elif previous_update.attribute != self.attribute:
             return None

--- a/nixui/options/state_update.py
+++ b/nixui/options/state_update.py
@@ -107,7 +107,8 @@ class SwapNamesUpdate(Update):
     attribute1: Attribute
 
     def revert(self, option_tree):
-        placeholder = str(uuid.uuid4())
+        # TODO: fix this hack, only using <name> because it isn't shown in OptionTree.children
+        placeholder = Attribute(f'"<name>".{uuid.uuid4()}')
         option_tree.rename_attribute(self.attribute0, placeholder)
         option_tree.rename_attribute(self.attribute1, self.attribute0)
         option_tree.rename_attribute(placeholder, self.attribute1)

--- a/nixui/options/types.py
+++ b/nixui/options/types.py
@@ -351,6 +351,9 @@ class EitherType(NixType):
         else:
             raise TypeError("Attempted to get child types, but no Either.subtypes allow children.", self)
 
+    def get_child_type(self, type_cls):
+        return [t for t in self.subtypes if isinstance(t, type_cls)][0]
+
 
 
 @dataclasses.dataclass(frozen=True, unsafe_hash=True)

--- a/nixui/state_model.py
+++ b/nixui/state_model.py
@@ -45,7 +45,8 @@ class StateModel:
         self._record_update(update)
 
     def swap_options(self, option0, option1):
-        placeholder = str(uuid.uuid4())
+        # TODO: fix this hack, only using <name> because it isn't shown in OptionTree.children
+        placeholder = Attribute(f'"<name>".{uuid.uuid4()}')
         self.option_tree.rename_attribute(option0, placeholder)
         self.option_tree.rename_attribute(option1, option0)
         self.option_tree.rename_attribute(placeholder, option1)


### PR DESCRIPTION
Rework `DynamicListOf` and `DynamicAttrsOf` so it follows an update-StateModel -> refresh navlist procedure to isolate the source of state to one place. This applies to all operations.

Further PRs (before v0.2 release):
-  Don't edit on double click, edit on f2
- Apply `max_renderable_field_widgets` so the universe of fields aren't rendered.
