### PR TITLE
upgrade: python39 -> python3

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -11,7 +11,7 @@
     flake-utils.lib.eachDefaultSystem (system:
       let
         pkgs = nixpkgs.legacyPackages.${system};
-        python = pkgs.python39;
+        python = pkgs.python3;
         pythonPackages = python.pkgs;
 
         nix-dump-syntax-tree-json = with pkgs; rustPlatform.buildRustPackage rec {


### PR DESCRIPTION
python3 is currently version 3.10 in nixpkgs